### PR TITLE
Error handling

### DIFF
--- a/app/assets/stylesheets/quotes.scss
+++ b/app/assets/stylesheets/quotes.scss
@@ -1,3 +1,12 @@
 // Place all the styles related to the Quotes controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.error {
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid;
+  border-radius: 4px;
+  font-weight: bold;
+  color: crimson;
+}

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -27,12 +27,11 @@ class QuotesController < ApplicationController
     result = BuildQuote.call(quote_params.merge(quote_currency: 'AUD')) # Eventually currency will be selected by the user
 
     respond_to do |format|
+      @quote = result.quote
       if result.success?
-        @quote = result.quote
         format.html { redirect_to @quote, notice: 'Quote was successfully created.' }
         format.json { render :show, status: :created, location: @quote }
       else
-        @quote = result.quote || Quote.new
         flash[:error] = result.error
         format.html { render :new }
         format.json { render json: result.error, status: :unprocessable_entity }

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -25,15 +25,17 @@ class QuotesController < ApplicationController
   # POST /quotes.json
   def create
     result = BuildQuote.call(quote_params.merge(quote_currency: 'AUD')) # Eventually currency will be selected by the user
-    @quote = result.quote
 
     respond_to do |format|
-      if @quote.save
+      if result.success?
+        @quote = result.quote
         format.html { redirect_to @quote, notice: 'Quote was successfully created.' }
         format.json { render :show, status: :created, location: @quote }
       else
+        @quote = result.quote || Quote.new
+        flash[:error] = result.error
         format.html { render :new }
-        format.json { render json: @quote.errors, status: :unprocessable_entity }
+        format.json { render json: result.error, status: :unprocessable_entity }
       end
     end
   end

--- a/app/interactors/build_quote.rb
+++ b/app/interactors/build_quote.rb
@@ -1,5 +1,5 @@
 class BuildQuote
   include Interactor::Organizer
 
-  organize SanitiseParams, ValidateAge, CalculateQuote, CreateQuote
+  organize CreateQuote, SanitiseParams, ValidateAge, CalculateQuote, SaveQuote
 end

--- a/app/interactors/build_quote.rb
+++ b/app/interactors/build_quote.rb
@@ -1,5 +1,5 @@
 class BuildQuote
   include Interactor::Organizer
 
-  organize SanitiseParams, CalculateQuote, CreateQuote
+  organize SanitiseParams, ValidateAge, CalculateQuote, CreateQuote
 end

--- a/app/interactors/calculate_quote.rb
+++ b/app/interactors/calculate_quote.rb
@@ -29,7 +29,7 @@ class CalculateQuote
 
   def lookup_quote(age, length)
     matching_rows = QUOTE_TABLE.select { |row| row.min_length <= length && row.max_length >= length && row.min_age <= age && row.max_age >= age }
-    context.fail!(error: "No quote available for age #{age}, trip length #{length}.") if matching_rows.empty?
+    context.fail!(error: I18n.t('no_quote', age: age, length: length)) if matching_rows.empty?
     raise RuntimeError.new("Overlapping quotes! Coding error in calculate_quote!") unless matching_rows.count == 1 # should NEVER happen!
     matching_rows.first.quote_cents
   end

--- a/app/interactors/calculate_quote.rb
+++ b/app/interactors/calculate_quote.rb
@@ -2,7 +2,8 @@ class CalculateQuote
   include Interactor
 
   def call
-    context.quote_cents = lookup_quote(context.age, context.trip_length)
+    quote = context.quote
+    quote.quote_cents = lookup_quote(quote.age, quote.trip_length)
   end
 
   private

--- a/app/interactors/calculate_quote.rb
+++ b/app/interactors/calculate_quote.rb
@@ -29,6 +29,8 @@ class CalculateQuote
 
   def lookup_quote(age, length)
     matching_rows = QUOTE_TABLE.select { |row| row.min_length <= length && row.max_length >= length && row.min_age <= age && row.max_age >= age }
+    context.fail!(error: "No quote available for age #{age}, trip length #{length}.") if matching_rows.empty?
+    raise RuntimeError.new("Overlapping quotes! Coding error in calculate_quote!") unless matching_rows.count == 1 # should NEVER happen!
     matching_rows.first.quote_cents
   end
 end

--- a/app/interactors/create_quote.rb
+++ b/app/interactors/create_quote.rb
@@ -5,15 +5,7 @@ class CreateQuote
     context.quote = Quote.new(
       age: context.age,
       trip_length: context.trip_length,
-      quote_cents: context.quote_cents,
       quote_currency: context.quote_currency
     )
-    context.fail!(error: error_message) unless context.quote.save
-  end
-
-  private
-
-  def error_message
-    "#{context.quote.errors.full_messages.join('. ')}."
   end
 end

--- a/app/interactors/create_quote.rb
+++ b/app/interactors/create_quote.rb
@@ -8,5 +8,12 @@ class CreateQuote
       quote_cents: context.quote_cents,
       quote_currency: context.quote_currency
     )
+    context.fail!(error: error_message) unless context.quote.save
+  end
+
+  private
+
+  def error_message
+    "#{context.quote.errors.full_messages.join('. ')}."
   end
 end

--- a/app/interactors/save_quote.rb
+++ b/app/interactors/save_quote.rb
@@ -1,0 +1,13 @@
+class SaveQuote
+  include Interactor
+
+  def call
+    context.fail!(error: error_message) unless context.quote.save
+  end
+
+  private
+
+  def error_message
+    "#{context.quote.errors.full_messages.join('. ')}."
+  end
+end

--- a/app/interactors/validate_age.rb
+++ b/app/interactors/validate_age.rb
@@ -1,0 +1,13 @@
+class ValidateAge
+  include Interactor
+
+  def call
+    if context.age < 18
+      context.fail!(error: I18n.t('too_young'))
+    end
+
+    if context.age > 69
+      context.fail!(error: I18n.t('too_old'))
+    end
+  end
+end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,4 +1,7 @@
 class Quote < ApplicationRecord
+
+  validates :age, :trip_length, :quote_cents, :quote_currency, presence: true
+
   def formatted_quote
     @quote ||= Money.new(quote_cents, quote_currency)
     @quote.format(:with_currency => true)

--- a/app/views/quotes/_form.html.erb
+++ b/app/views/quotes/_form.html.erb
@@ -1,16 +1,4 @@
 <%= form_with(model: quote, local: true) do |form| %>
-  <% if quote.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(quote.errors.count, "error") %> prohibited this quote from being saved:</h2>
-
-      <ul>
-      <% quote.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <% if flash[:error] %>
     <div class="error"><%= flash[:error] %></div>
   <% end %>

--- a/app/views/quotes/_form.html.erb
+++ b/app/views/quotes/_form.html.erb
@@ -11,6 +11,10 @@
     </div>
   <% end %>
 
+  <% if flash[:error] %>
+    <div class="error"><%= flash[:error] %></div>
+  <% end %>
+
   <div class="field">
     <%= form.label :age, t(:age_of_traveller) %>
     <%= form.number_field :age, id: :quote_age %>

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -9,5 +9,4 @@
          formatted_quote: @quote.formatted_quote) %>
 </p>
 
-<%= link_to 'Edit', edit_quote_path(@quote) %> |
-<%= link_to 'Back', quotes_path %>
+<%= link_to 'Get Another Quote', new_quote_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,3 +41,6 @@ en:
   get_quote: 'Get Quote'
   give_quote: "A trip of %{trip_length} for a traveller aged %{traveller_age} will cost %{formatted_quote}"
   give_quote_heading: "Here's your quote"
+  too_young: 'Sorry, travellers under the age of 18 are not covered by our policy'
+  too_old: 'Sorry, travellers over the age of 69 are not covered by our policy'
+  no_quote: "No quote available for age %{age}, trip length %{length}."

--- a/test/interactors/calculate_quote_test.rb
+++ b/test/interactors/calculate_quote_test.rb
@@ -64,13 +64,13 @@ class CalculateQuoteTest < ActiveSupport::TestCase
 
   test_expectations.each do |te|
     test "calculates the amount of the quote when age is #{te.age} and trip length is #{te.trip_length}" do
-      result = CalculateQuote.call(age: te.age, trip_length: te.trip_length, quote_currency: 'AUD')
-      assert_equal te.quote_cents, result.quote_cents
+      result = CalculateQuote.call(quote: Quote.new(age: te.age, trip_length: te.trip_length, quote_currency: 'AUD'))
+      assert_equal te.quote_cents, result.quote.quote_cents
     end
   end
 
   test "fails if the quote is not found" do
-    result = CalculateQuote.call(age: 0, trip_length: 0, quote_currency: 'AUD')
+    result = CalculateQuote.call(quote: Quote.new(age: 0, trip_length: 0, quote_currency: 'AUD'))
     assert_equal 'No quote available for age 0, trip length 0.', result.error
   end
 end

--- a/test/interactors/calculate_quote_test.rb
+++ b/test/interactors/calculate_quote_test.rb
@@ -68,4 +68,9 @@ class CalculateQuoteTest < ActiveSupport::TestCase
       assert_equal te.quote_cents, result.quote_cents
     end
   end
+
+  test "fails if the quote is not found" do
+    result = CalculateQuote.call(age: 0, trip_length: 0, quote_currency: 'AUD')
+    assert_equal 'No quote available for age 0, trip length 0.', result.error
+  end
 end

--- a/test/interactors/create_quote_test.rb
+++ b/test/interactors/create_quote_test.rb
@@ -8,4 +8,16 @@ class CalculateQuoteTest < ActiveSupport::TestCase
     assert_equal 15_23, quote.quote_cents
     assert_equal 'AUD', quote.quote_currency
   end
+
+  test 'saves the quote' do
+    result = CreateQuote.call(age: 37, trip_length: 5, quote_cents: 15_23, quote_currency: 'AUD')
+    assert_equal true, result.success?
+    assert_not_nil result.quote.id
+  end
+
+  test 'fails if the quote cannot be saved' do
+    result = CreateQuote.call(age:nil, trip_length: nil, quote_cents: 15_23, quote_currency: 'AUD')
+    assert_equal false, result.success?
+    assert_equal "Age can't be blank. Trip length can't be blank.", result.error
+  end
 end

--- a/test/interactors/create_quote_test.rb
+++ b/test/interactors/create_quote_test.rb
@@ -1,23 +1,11 @@
 require 'test_helper'
 
-class CalculateQuoteTest < ActiveSupport::TestCase
-  test 'creates the quote model' do
-    quote = CreateQuote.call(age: 37, trip_length: 5, quote_cents: 15_23, quote_currency: 'AUD').quote
+class CreateQuoteTest < ActiveSupport::TestCase
+  test 'creates the quote model (minus the quote cents)' do
+    quote = CreateQuote.call(age: 37, trip_length: 5, quote_currency: 'AUD').quote
     assert_equal 37, quote.age
     assert_equal 5, quote.trip_length
-    assert_equal 15_23, quote.quote_cents
+    assert_equal nil, quote.quote_cents
     assert_equal 'AUD', quote.quote_currency
-  end
-
-  test 'saves the quote' do
-    result = CreateQuote.call(age: 37, trip_length: 5, quote_cents: 15_23, quote_currency: 'AUD')
-    assert_equal true, result.success?
-    assert_not_nil result.quote.id
-  end
-
-  test 'fails if the quote cannot be saved' do
-    result = CreateQuote.call(age:nil, trip_length: nil, quote_cents: 15_23, quote_currency: 'AUD')
-    assert_equal false, result.success?
-    assert_equal "Age can't be blank. Trip length can't be blank.", result.error
   end
 end

--- a/test/interactors/save_quote_test.rb
+++ b/test/interactors/save_quote_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class SaveQuoteTest < ActiveSupport::TestCase
+  test 'saves the quote' do
+    valid_quote = Quote.new(age: 37, trip_length: 5, quote_cents: 15_23, quote_currency: 'AUD')
+    result = SaveQuote.call(quote: valid_quote)
+    assert_equal true, result.success?
+    assert_not_nil result.quote.id
+  end
+
+  test 'fails if the quote cannot be saved' do
+    invalid_quote = Quote.new(age: nil, trip_length: nil, quote_cents: 15_23, quote_currency: 'AUD')
+    result = SaveQuote.call(quote: invalid_quote)
+    assert_equal false, result.success?
+    assert_equal "Age can't be blank. Trip length can't be blank.", result.error
+  end
+end

--- a/test/interactors/validate_age_test.rb
+++ b/test/interactors/validate_age_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ValidateAgeTest < ActiveSupport::TestCase
+  test "fails if age is less than 18" do
+    result = ValidateAge.call(age: 15, trip_length: 17)
+    assert_equal false, result.success?
+    assert_equal I18n.t('too_young'), result.error
+  end
+
+  test "fails if age is over 69" do
+    result = ValidateAge.call(age: 70, trip_length: 17)
+    assert_equal false, result.success?
+    assert_equal I18n.t('too_old'), result.error
+  end
+end

--- a/test/models/quote_test.rb
+++ b/test/models/quote_test.rb
@@ -11,4 +11,10 @@ class QuoteTest < ActiveSupport::TestCase
     quote.save!
     assert_equal '$15.21 USD', quote.reload.formatted_quote
   end
+
+  test 'it validates the presence of all fields' do
+    quote = Quote.new
+    assert_not quote.valid?
+    assert_equal [:age, :trip_length, :quote_cents, :quote_currency], quote.errors.keys
+  end
 end

--- a/test/system/basic_policy_quotes_test.rb
+++ b/test/system/basic_policy_quotes_test.rb
@@ -12,4 +12,14 @@ class BasicPolicyQuotesTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Here's your quote"
     assert_text "A trip of up to 7 days for a traveller aged 51 will cost $60.00 AUD"
   end
+
+  test "Traveller is too young" do
+    visit new_quote_path
+
+    fill_in "Age of Traveller", with: "17"
+    select('Up to 7 days', :from=>:trip_length)
+    click_on "Get Quote"
+
+    assert_text 'Sorry, travellers under the age of 18 are not covered by our policy'
+  end
 end

--- a/test/system/quotes_flow_test.rb
+++ b/test/system/quotes_flow_test.rb
@@ -15,4 +15,16 @@ class QuotesFlowTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Here's your quote"
     assert_text 'A trip of up to 7 days for a traveller aged 69 will cost $70.00 AUD'
   end
+
+  test 'Get quote, then return for a second quote' do
+    visit new_quote_path
+
+    fill_in "Age of Traveller", with: "35"
+    select('8 to 14 days', :from=>:trip_length)
+    click_on "Get Quote"
+    assert_selector "h1", text: "Here's your quote"
+
+    click_on "Get Another Quote"
+    assert_selector "h1", text: "How much will my travel insurance cost?"
+  end
 end

--- a/test/system/quotes_flow_test.rb
+++ b/test/system/quotes_flow_test.rb
@@ -1,0 +1,18 @@
+require "application_system_test_case"
+
+class QuotesFlowTest < ApplicationSystemTestCase
+  test 'Correct an error and retry' do
+    visit new_quote_path
+
+    fill_in "Age of Traveller", with: "70"
+    select('Up to 7 days', :from=>:trip_length)
+    click_on "Get Quote"
+    assert_text 'Sorry, travellers over the age of 69 are not covered by our policy'
+    assert_field 'Age of Traveller', with: '70'
+
+    fill_in "Age of Traveller", with: "69"
+    click_on "Get Quote"
+    assert_selector "h1", text: "Here's your quote"
+    assert_text 'A trip of up to 7 days for a traveller aged 69 will cost $70.00 AUD'
+  end
+end


### PR DESCRIPTION
# This PR

This PR is the final in the series for the card "Supply basic policy prices"
In this PR I validate the age of the traveller. Any error message from the validator is displayed on the form. The traveller can see their original input values and correct any errors before trying again.

I've also replaced the links to the update quote page and the list of quotes, which a traveller shouldn't see, with a link back to the new quote page.

This is how an age error looks:

---

<img width="651" alt="screen shot 2018-04-01 at 6 27 50 pm" src="https://user-images.githubusercontent.com/1095688/38171323-f00de98c-35da-11e8-942f-75a75ac682b1.png">

---

And  here's the quote screen with back link:

---
<img width="471" alt="screen shot 2018-04-01 at 9 37 07 pm" src="https://user-images.githubusercontent.com/1095688/38172720-e050aa38-35f4-11e8-9204-900c4a38c723.png">


---

# Card: Supply basic policy prices
As a traveller  
I want to get a quote for a travel insurance policy  
So that I can decide whether to purchase one

# Conversation
See PR #1 

# Confirmation
 - [x] Trips can be any number of days in length from 0 up.
 - [x] Travellers must be between the ages of 18 and 69. Other ages provide an error message.
 - [x] Prices can have cents and a currency. Only AUD is required for now.
 - [x] Prices may be hardcoded for now.
 - [x] Taxes may be ignored for now
 - [x] User interface strings are only English for now but must be translatable
 - [x] User interface can be basic for now.