### PR TITLE
Strengthen validation

### DIFF
--- a/app/interactors/build_quote.rb
+++ b/app/interactors/build_quote.rb
@@ -3,5 +3,5 @@
 class BuildQuote
   include Interactor::Organizer
 
-  organize CreateQuote, CalculateAge, ValidateAge, CalculateTripLength, CalculateQuote, SaveQuote
+  organize CreateQuote, ValidateTripDates, CalculateAge, ValidateAge, CalculateTripLength, CalculateQuote, SaveQuote
 end

--- a/app/interactors/calculate_quote.rb
+++ b/app/interactors/calculate_quote.rb
@@ -11,7 +11,7 @@ class CalculateQuote
 
   private
 
-  MAX_TRIP_LENGTH = 365_00 # Code is simpler if we assume no-one will take a trip longer than 100 years. Seems safe!
+  MAX_TRIP_DAYS = 365
 
   QUOTE_TABLE = [
     OpenStruct.new(min_length: 0, max_length: 7, min_age: 18, max_age: 49, quote_cents: 50_00),
@@ -26,9 +26,9 @@ class CalculateQuote
     OpenStruct.new(min_length: 15, max_length: 21, min_age: 50, max_age: 59, quote_cents: 80_00),
     OpenStruct.new(min_length: 15, max_length: 21, min_age: 60, max_age: 69, quote_cents: 90_00),
 
-    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_LENGTH, min_age: 18, max_age: 49, quote_cents: 82_00),
-    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_LENGTH, min_age: 50, max_age: 59, quote_cents: 90_00),
-    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_LENGTH, min_age: 60, max_age: 69, quote_cents: 100_00)
+    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_DAYS, min_age: 18, max_age: 49, quote_cents: 82_00),
+    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_DAYS, min_age: 50, max_age: 59, quote_cents: 90_00),
+    OpenStruct.new(min_length: 22, max_length: MAX_TRIP_DAYS, min_age: 60, max_age: 69, quote_cents: 100_00)
   ].freeze
 
   def lookup_quote(age, length)

--- a/app/interactors/validate_trip_dates.rb
+++ b/app/interactors/validate_trip_dates.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class ValidateTripDates
+  include Interactor
+
+  # This method is simple to understand despite its ABC size. There seemed no good way to shorten it.
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def call
+    quote = context.quote
+    context.fail!(error: start_date_message) if quote.trip_starts_at.nil?
+    context.fail!(error: end_date_message) if quote.trip_ends_at.nil?
+    context.fail!(error: start_future_message) if quote.trip_starts_at <= Time.current
+    context.fail!(error: start_before_end_message) if quote.trip_starts_at >= quote.trip_ends_at
+    context.fail!(error: max_future_message) if quote.trip_starts_at > 1.year.from_now
+    context.fail!(error: max_length_message) if quote.trip_ends_at - quote.trip_starts_at > 1.year
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  private
+
+  def start_date_message
+    I18n.t('cant_be_blank', field: I18n.t('trip_start_date'))
+  end
+
+  def end_date_message
+    I18n.t('cant_be_blank', field: I18n.t('trip_end_date'))
+  end
+
+  def start_future_message
+    I18n.t('must_be_future', field: I18n.t('trip_start_date'))
+  end
+
+  def start_before_end_message
+    I18n.t('must_be_after', field1: I18n.t('trip_start_date').downcase, field2: I18n.t('trip_end_date'))
+  end
+
+  def max_future_message
+    I18n.t('trip_max_future')
+  end
+
+  def max_length_message
+    I18n.t('trip_max_length')
+  end
+end

--- a/app/interactors/validate_trip_dates.rb
+++ b/app/interactors/validate_trip_dates.rb
@@ -13,7 +13,7 @@ class ValidateTripDates
     context.fail!(error: start_future_message) if quote.trip_starts_at <= Time.current
     context.fail!(error: start_before_end_message) if quote.trip_starts_at >= quote.trip_ends_at
     context.fail!(error: max_future_message) if quote.trip_starts_at > 1.year.from_now
-    context.fail!(error: max_length_message) if quote.trip_ends_at - quote.trip_starts_at > 1.year
+    context.fail!(error: max_length_message) if trip_length(quote) > CalculateQuote::MAX_TRIP_DAYS.days
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -42,5 +42,9 @@ class ValidateTripDates
 
   def max_length_message
     I18n.t('trip_max_length')
+  end
+
+  def trip_length(quote)
+    quote.trip_ends_at - quote.trip_starts_at
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,13 @@ en:
   date_of_birth: 'What is your date of birth?'
   trip_starts_at: 'When does your trip start?'
   trip_ends_at: 'When does your trip end?'
+  trip_start_date: 'Trip start date'
+  trip_end_date: 'Trip end date'
+  cant_be_blank: "%{field} can't be blank"
+  must_be_future: '%{field} must be in the future'
+  must_be_after: '%{field2} must be after %{field1}'
+  trip_max_future: 'Trip start date must be within a year from now'
+  trip_max_length: 'Sorry, we only cover trips up to one year long'
   get_quote: 'Get Quote'
   give_quote: "A trip of %{trip_length} days for a traveller aged %{traveller_age} will cost %{formatted_quote}"
   give_quote_heading: "Here's your quote"

--- a/test/interactors/validate_dates_test.rb
+++ b/test/interactors/validate_dates_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ValidateDatesTest < ActiveSupport::TestCase
+  test 'fails if start date is blank' do
+    result = ValidateTripDates.call(quote: Quote.new(trip_ends_at: 1.month.from_now))
+    assert_equal false, result.success?
+    assert_equal "Trip start date can't be blank", result.error
+  end
+
+  test 'fails if end date is blank' do
+    result = ValidateTripDates.call(quote: Quote.new(trip_starts_at: 2.months.from_now))
+    assert_equal false, result.success?
+    assert_equal "Trip end date can't be blank", result.error
+  end
+
+  test 'fails if start date is not in the future' do
+    result = ValidateTripDates.call(quote: Quote.new(trip_starts_at: Time.current, trip_ends_at: 2.days.from_now))
+    assert_equal false, result.success?
+    assert_equal 'Trip start date must be in the future', result.error
+  end
+
+  test 'fails if start date is after end date' do
+    result = ValidateTripDates.call(quote: Quote.new(trip_starts_at: 3.days.from_now, trip_ends_at: 2.days.from_now))
+    assert_equal false, result.success?
+    assert_equal 'Trip end date must be after trip start date', result.error
+  end
+
+  test 'fails if start date more than a year in the future' do
+    result = ValidateTripDates.call(quote: Quote.new(
+      trip_starts_at: 1.year.from_now + 1.second,
+      trip_ends_at: 1.year.from_now + 1.week
+    ))
+    assert_equal false, result.success?
+    assert_equal 'Trip start date must be within a year from now', result.error
+  end
+
+  test 'fails if the trip is more than a year long' do
+    result = ValidateTripDates.call(quote: Quote.new(
+      trip_starts_at: 3.days.from_now,
+      trip_ends_at: 1.year.from_now + 4.days
+    ))
+    assert_equal false, result.success?
+    assert_equal 'Sorry, we only cover trips up to one year long', result.error
+  end
+end

--- a/test/system/basic_policy_quotes_test.rb
+++ b/test/system/basic_policy_quotes_test.rb
@@ -18,15 +18,4 @@ class BasicPolicyQuotesTest < ApplicationSystemTestCase
     assert_selector 'h1', text: "Here's your quote"
     assert_text 'A trip of 7 days for a traveller aged 51 will cost $60.00 AUD'
   end
-
-  test 'Traveller is too young' do
-    visit new_quote_path
-
-    select_date Date.parse('27/08/2001'), from: 'quote_date_of_birth'
-    fill_in 'quote_trip_starts_at', with: "20/08/2018 \t0345p"
-    fill_in 'quote_trip_ends_at', with: "27/08/2018 \t0345p"
-    click_on 'Get Quote'
-
-    assert_text 'Sorry, travellers under the age of 18 are not covered by our policy'
-  end
 end

--- a/test/system/validation_test.rb
+++ b/test/system/validation_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ValidationTest < ApplicationSystemTestCase
+  include DateSelectHelper
+
+  test 'Polite error message is given if start date is missing' do
+    visit new_quote_path
+
+    assert_selector 'h1', text: 'How much will my travel insurance cost?'
+    select_date Date.parse('26/08/1966'), from: 'quote_date_of_birth'
+    fill_in 'quote_trip_ends_at', with: "20/08/2018 \t0345p"
+    click_on 'Get Quote'
+
+    assert_text "Trip start date can't be blank"
+  end
+
+  test 'Polite error message is given if end date is missing' do
+    visit new_quote_path
+
+    assert_selector 'h1', text: 'How much will my travel insurance cost?'
+    select_date Date.parse('26/08/1966'), from: 'quote_date_of_birth'
+    fill_in 'quote_trip_starts_at', with: "20/08/2018 \t0345p"
+    click_on 'Get Quote'
+
+    assert_text "Trip end date can't be blank"
+  end
+
+  test 'Traveller is too young' do
+    visit new_quote_path
+
+    select_date Date.parse('27/08/2001'), from: 'quote_date_of_birth'
+    fill_in 'quote_trip_starts_at', with: "20/08/2018 \t0345p"
+    fill_in 'quote_trip_ends_at', with: "27/08/2018 \t0345p"
+    click_on 'Get Quote'
+
+    assert_text 'Sorry, travellers under the age of 18 are not covered by our policy'
+  end
+
+  test 'Traveller is too old' do
+    visit new_quote_path
+
+    select_date Date.parse('01/01/1948'), from: 'quote_date_of_birth'
+    fill_in 'quote_trip_starts_at', with: "20/08/2018 \t0345p"
+    fill_in 'quote_trip_ends_at', with: "27/08/2018 \t0345p"
+    click_on 'Get Quote'
+
+    assert_text 'Sorry, travellers over the age of 69 are not covered by our policy'
+  end
+end


### PR DESCRIPTION
# Card
As a traveller who has made an error when filling in the quote form
I want to receive an error message I can understand
So that I can correct my quote and try again

# Conversation
_Jun-li, the team's tester, comes to talk to MAC_

Jun-li: Hi MAC. I've been having a look at the quote page. If I forget to fill in one of my trip dates I get a nasty error message that looks like this:

```
NoMethodError in QuotesController#create
undefined method `-@' for nil:NilClass
```

MAC: Oh, whoops. I used to rely on the saving of the quote to provide a friendly error message about missing trip dates, but now that doesn't happen until after we try to use those fields when calculating the traveller's age. I'll add some validation to ensure we have those before we try to use them.

Jun-li: Would be good if we also give a friendly message if the traveller accidentally enters a trip start date that is in the past, or a trip end date that is before the start date.

MAC: Ah, good thinking. Yes, I'll fix that up.

Jun-li: Do you know what the maximum possible trip length is, or how far in the future the trip could start and the quote still be valid? Like could you get a quote now for a trip 10 years in the future?

MAC: I made an assumption in the code that no trip could be longer than 100 years, but that seems a bit excessive. These are business policies. Let's ask Sarah.

_MAC and Jun-li go to see Sarah, the product analyst_

Jun-li: Hi Sarah. Do we have policies on how far in the future a trip can be when we ask for a quote? And how long a trip can be?

Sarah: Oh yes, thanks for asking. We have a limit on one year between the time the quote is requested and the time the trip must start. Also, we only cover trips up to one year long.

MAC: Thanks Sarah and Jun-li. I'll make sure we validate the trip dates and provide friendly error messages to the travellers.

# Confirmation
- [x] Validate that trip start and end dates are present before traveller age is calculated
- [x] Validate that the trip starts in the future
- [x] Validate that the trip ends after it starts
- [x] Validate that the trip starts within a year from now
- [x] Validate that the trip is no more than a year long

